### PR TITLE
feat(powershell): improve settings with completions, profile updates, and style fixes

### DIFF
--- a/windows/settings/powershell/.vscode/cSpell/dicts/powershell.dic
+++ b/windows/settings/powershell/.vscode/cSpell/dicts/powershell.dic
@@ -3,6 +3,7 @@ inshellisense
 multisource
 ocaml
 opam
+ramdisk
 SCRIPTSDIR
 wakatime
 Wakatime

--- a/windows/settings/powershell/Microsoft.PowerShell_profile.ps1
+++ b/windows/settings/powershell/Microsoft.PowerShell_profile.ps1
@@ -96,7 +96,6 @@ function private:Set-WorkingDir() {
 function Invoke-SfwPnpm() { & sfw pnpm @args }
 Set-Alias pnpm Invoke-SfwPnpm -Description { "safe pnpm" }
 
-
 ##
 Set-WorkingDir
 
@@ -120,7 +119,7 @@ Invoke-Expression (&scoop-search-multisource -hook)
 $env:CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense' # optional
 Set-PSReadLineOption -Colors @{ "Selection" = "`e[7m" }
 Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
-carapace _carapace | Out-String | Invoke-Expression # setup source in completion.d
+# carapace _carapace | Out-String | Invoke-Expression # setup source in completion.d
 
 ## tab completion
 Import-Module -Name CompletionPredictor

--- a/windows/settings/powershell/Microsoft.PowerShell_profile.ps1
+++ b/windows/settings/powershell/Microsoft.PowerShell_profile.ps1
@@ -80,8 +80,8 @@ function private:write-sudo-messages() {
 }
 
 <#
-	.SYNOPSIS
-	set current working directory to workspaces if call from menu/explorer
+    .SYNOPSIS
+    set current working directory to workspaces if call from menu/explorer
 #>
 function private:Set-WorkingDir() {
   $cur = Get-Location
@@ -91,6 +91,12 @@ function private:Set-WorkingDir() {
 }
 
 ### main routine
+
+## use firewall for npm,pnpm safer
+function Invoke-SfwPnpm() { & sfw pnpm @args }
+Set-Alias pnpm Invoke-SfwPnpm -Description { "safe pnpm" }
+
+
 ##
 Set-WorkingDir
 
@@ -98,6 +104,7 @@ Set-WorkingDir
 Set-PSReadLineOption -PredictionSource HistoryAndPlugin
 Set-PSReadLineOption -PredictionViewStyle ListView
 Set-PSReadLineOption -Colors @{ InLinePrediction = [ConsoleColor]::Cyan }
+Set-PSReadlineOption -HistoryNoDuplicates
 
 ## key binding
 . ($agLIBSDIR + "keyConfig.inc.ps1" )
@@ -113,7 +120,7 @@ Invoke-Expression (&scoop-search-multisource -hook)
 $env:CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense' # optional
 Set-PSReadLineOption -Colors @{ "Selection" = "`e[7m" }
 Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
-# carapace _carapace | Out-String | Invoke-Expression # setup source in completion.d
+carapace _carapace | Out-String | Invoke-Expression # setup source in completion.d
 
 ## tab completion
 Import-Module -Name CompletionPredictor
@@ -136,3 +143,4 @@ $env:NODE_PATH = $env:PNPM_HOME + "\5\node_modules"
 if ([aglaUserRole]::isAdmin()) {
   write-sudo-messages;
 }
+

--- a/windows/settings/powershell/completion.d/git-wt.ps1
+++ b/windows/settings/powershell/completion.d/git-wt.ps1
@@ -1,0 +1,11 @@
+# src: Documentation/powershell/completion.d/git-wt.ps1
+# @(#) : worktrunk (git-wt) completion for powershell
+#
+# Copyright (c) 2025 Furukawa Atsushi <atsushifx@gmail.com>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+if (command git-wt) {
+  git-wt config shell init powershell | Out-String | Invoke-Expression
+}

--- a/windows/settings/powershell/completion.d/git-wt.ps1
+++ b/windows/settings/powershell/completion.d/git-wt.ps1
@@ -6,6 +6,33 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
-if (command git-wt) {
-  git-wt config shell init powershell | Out-String | Invoke-Expression
+if (Get-Command git-wt -ErrorAction SilentlyContinue) {
+    $gitWtCompleter = {
+        param($wordToComplete, $commandAst, $cursorPosition)
+
+        $prev = $env:COMPLETE
+        $env:COMPLETE = "powershell"
+
+        $cmdLine = $commandAst.Extent.Text
+        $cmdLine = $cmdLine.Substring(0, [math]::Min($cursorPosition, $cmdLine.Length))
+        if ($wordToComplete -eq "") { $cmdLine += " ''" }
+
+        $wtBin = (Get-Command git-wt -CommandType Application | Select-Object -First 1).Source
+        $results = & $wtBin -- ($cmdLine -split ' ') 2>$null
+
+        if ($null -eq $prev) {
+            Remove-Item Env:\COMPLETE -ErrorAction SilentlyContinue
+        } else {
+            $env:COMPLETE = $prev
+        }
+
+        $results | ForEach-Object {
+            $split = $_.Split("`t")
+            $cmd = $split[0]
+            $help = if ($split.Length -eq 2) { $split[1] } else { $split[0] }
+            [System.Management.Automation.CompletionResult]::new($cmd, $cmd, 'ParameterValue', $help)
+        }
+    }
+
+    Register-ArgumentCompleter -Native -CommandName 'git-wt', 'git-wt.exe' -ScriptBlock $gitWtCompleter
 }

--- a/windows/settings/powershell/completion.d/git.ps1
+++ b/windows/settings/powershell/completion.d/git.ps1
@@ -1,7 +1,7 @@
 <#
   .SYNOPSIS
     git completion for powershell
-  
+
   .DESCRIPTION
     set up git completion with posh-git
 
@@ -12,7 +12,7 @@
     @date     2023-05-31
     @Version  1.0.0
 
-THIS CODE IS MADE AVAILABLE AS IS, WITHOUT WARRANTY OF ANY KIND. 
+THIS CODE IS MADE AVAILABLE AS IS, WITHOUT WARRANTY OF ANY KIND.
 THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS CODE REMAINS WITH THE USER.
 #>
 

--- a/windows/settings/powershell/completion.d/volta.ps1
+++ b/windows/settings/powershell/completion.d/volta.ps1
@@ -17,4 +17,4 @@ THIS CODE IS MADE AVAILABLE AS IS, WITHOUT WARRANTY OF ANY KIND.
 THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS CODE REMAINS WITH THE USER.
 #>
 
-# volta completions powershell | Out-String | Invoke-Expression
+volta completions powershell | Out-String | Invoke-Expression

--- a/windows/settings/powershell/libs/cliFunctions.inc.ps1
+++ b/windows/settings/powershell/libs/cliFunctions.inc.ps1
@@ -6,11 +6,11 @@ command line editing functions library
 command line function library for powershell.
 
 .NOTES
-@Author		Furukawa, Atsushi <atsushifx@aglabo.com>
-@License 	MIT License https://opensource.org/licenses/MIT
+@Author     Furukawa, Atsushi <atsushifx@aglabo.com>
+@License    MIT License https://opensource.org/licenses/MIT
 
-@date			2023-05-31
-@Version 	1.1.0
+@date           2023-05-31
+@Version    1.1.0
 
 THIS CODE IS MADE AVAILABLE AS IS, WITHOUT WARRANTY OF ANY KIND.
 THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS CODE REMAINS WITH THE USER.
@@ -18,61 +18,62 @@ THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS CODE REMAINS WITH
 Set-StrictMode -version latest
 
 ###
-###		Functions
+###     Functions
 ###
 
 <#
 .SYNOPSIS
-	Retrieves the global command history from the PowerShell history file.
+    Retrieves the global command history from the PowerShell history file.
 
 .DESCRIPTION
-	The `Get-Global-History` function reads the command history from PSReadLine's history file,
-	removes any empty lines and duplicate entries, and returns the cleaned global command history.
-	You can optionally specify the number of entries to retrieve from the beginning or the end of the history.
+    The `Get-Global-History` function reads the command history from PSReadLine's history file,
+    removes any empty lines and duplicate entries, and returns the cleaned global command history.
+    You can optionally specify the number of entries to retrieve from the beginning or the end of the history.
 
 .PARAMETER Head
-	An integer specifying the number of entries to retrieve from the beginning of the history.
+    An integer specifying the number of entries to retrieve from the beginning of the history.
 
 .PARAMETER Tail
-	An integer specifying the number of entries to retrieve from the end of the history.
+    An integer specifying the number of entries to retrieve from the end of the history.
 
 .EXAMPLE
   Get-Global-History -Tail 20
 
-	Retrieves the last 20 commands from the global history.
+    Retrieves the last 20 commands from the global history.
 
 .NOTES
-	Requires:
-	- PowerShell 5.0 or later
-	- PSReadLine module
-	
-	Description:
-		This function accesses the persistent command history file used by PSReadLine,
+    Requires:
+    - PowerShell 5.0 or later
+    - PSReadLine module
+
+    Description:
+        This function accesses the persistent command history file used by PSReadLine,
 #>
 function global:Get-Global-History() {
-	param(
-		[int]$Head,
-		[int]$Tail
-	)
-	## main routin
-	begin {
-		$globalHistoryCommand = '(Get-Content -Path (Get-PSReadLineOption).HistorySavePath)'
-	}
-	process {
-		$globalHistoryAll = (Invoke-Expression $globalHistoryCommand)
-	}
+    param(
+        [int]$Head,
+        [int]$Tail
+    )
 
-	end {
-		$history = ($globalHistoryAll)	| Where-Object { $_ -ne "" } |		Select-Object -Unique
-		
-		if ($Head -gt 0) {
-			$history = $history | Select-Object	-First $Head
-		}
-		if ($Tail -gt 0) {
-			$history = $history | Select-Object -Last $Tail
-		}
-		$history
-	}
+    begin {
+        $historyPath = (Get-PSReadLineOption).HistorySavePath
+        $maxHistoryCount = 100
+    }
+    process {
+        $globalHistory = (Get-Content -Path $historyPath)| tail -$maxHistoryCount | Where-Object { $_ -ne "" } | Select-Object -Unique
+    }
+    end {
+        echo ($globalHistory.Count)
+        $history = $globalHistory
+
+        if ($Head -gt 0) {
+            $history = $history | Select-Object -First $Head
+        }
+        if ($Tail -gt 0) {
+            $history = $history | Select-Object -Last $Tail
+        }
+        $history
+    }
 }
 Set-Alias -Name ggh -Value global:Get-Global-History -Description { "get global history from PSReadLine" }
 
@@ -98,103 +99,103 @@ use with "-Send", this switch send "Enter" to execute command.
 .NOTES
 This script provides a convenient way to execute commands with enhanced control over command history and editing.
 #>
-function global:Execute_Command() {
-	param(
-		[Parameter(Mandatory)][string]$command,
-		[Switch]$Send,
-		[Switch]$Enter
-	)
+function global:Execute-Command() {
+    param(
+        [Parameter(Mandatory)][string]$command,
+        [Switch]$Send,
+        [Switch]$Enter
+    )
 
-	if ($send) {
-		# execute command with readline function
-		[Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
-		[Microsoft.PowerShell.PSConsoleReadLine]::Insert($command)
-		[Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
-		
-		if ($Enter) {
-			[Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
-		}
-	}
-	else {
-		Invoke-Expression($command)
-	}
+    if ($send) {
+        # execute command with readline function
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+        [Microsoft.PowerShell.PSConsoleReadLine]::Insert($command)
+        [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+
+        if ($Enter) {
+            [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+        }
+    }
+    else {
+        Invoke-Expression($command)
+    }
 }
 
 <#
 .SYNOPSIS
-	Selects a command from history using fzf and edit or executes it.
+    Selects a command from history using fzf and edit or executes it.
 
 .DESCRIPTION
-	The `Execute_History` function displays the command history from newest to oldest.
-	It allows you to select a command using `fzf`. You can choose to execute the selected
-	command immediately or insert it into the command line for editing before execution
-	by using the `-Send` switch.
-	
+    The `Execute_History` function displays the command history from newest to oldest.
+    It allows you to select a command using `fzf`. You can choose to execute the selected
+    command immediately or insert it into the command line for editing before execution
+    by using the `-Send` switch.
+
 .PARAMETER Send
-	true: select command is inserted in to command line to edit before execute it.
+    true: select command is inserted in to command line to edit before execute it.
 
 .NOTES
-	Requires:
+    Requires:
   - PowerShell 5.0 or later
-	- `tac` (from BusyBox or CoreUtils)
-	- `fzf` (fuzzy finder) installed and available in the system PATH
+    - `tac` (from BusyBox or CoreUtils)
+    - `fzf` (fuzzy finder) installed and available in the system PATH
 
 #>
-function Execute_History() {
-	param(
-		[switch]$send
-	)
-	
-	$command = (global:Get-Global-History -Tail 20) | tac | fzf --select-1 
-	if ($?) {
-		Execute_Command $command -send:$send
-	}
-	else {
-		[Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
-	}
+function Execute-History() {
+    param(
+        [switch]$send
+    )
+
+    $command = (global:Get-Global-History -Tail 20) | tac | fzf --select-1
+    if ($?) {
+        Execute-Command $command -send:$send
+    }
+    else {
+        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+    }
 }
-Set-Alias -Name hh -Value "Execute_History"
+Set-Alias -Name hh -Value "Execute-History"
 
 <#
 .SYNOPSIS
-	Get Process Object of Parent Process called by ProcessID
+    Get Process Object of Parent Process called by ProcessID
 
 .DESCRIPTION
-	The `Get-ParentProcessId` function find Parent Process ID (PPID) using WMI.
-	
-.PARAMETER ProcessId
-	The Process ID (PID) of the child process
-	
-.EXAMPLE
-	Get-ParentProcessId $PID
+    The `Get-ParentProcessId` function find Parent Process ID (PPID) using WMI.
 
-	the PPID from $PID (=powershell) is Windows Terminal's ID
+.PARAMETER ProcessId
+    The Process ID (PID) of the child process
+
+.EXAMPLE
+    Get-ParentProcessId $PID
+
+    the PPID from $PID (=powershell) is Windows Terminal's ID
 
 .NOTES
-	Requirements:
-		- Appropriate permissions to perform WMI queries.
-		- WMI must be enabled and accessible on the system.
-	
-	Caution:
-		- Some security software may block WMI queries, which can prevent this function from working properly.
+    Requirements:
+        - Appropriate permissions to perform WMI queries.
+        - WMI must be enabled and accessible on the system.
+
+    Caution:
+        - Some security software may block WMI queries, which can prevent this function from working properly.
 
 .LINK
-	- [Get-Process](https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-process)
+    - [Get-Process](https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-process)
   - [Get-WmiObject](https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-wmiobject)
 
 #>
 function global:Get-ParentProcessId {
-	param (
-		[Parameter(Mandatory = $true,
-			Position = 0,
-			ValueFromPipeline = $true,
-			ValueFromPipelineByPropertyName = $true)]
-		[int]$ProcessID
-	)
+    param (
+        [Parameter(Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true)]
+        [int]$ProcessID
+    )
 
-	process {
-		$query = "SELECT ParentProcessId FROM Win32_Process WHERE ProcessId = $ProcessId"
-		$parentID = (Get-WmiObject -Query $query).ParentProcessId
-		$parentID
-	}
+    process {
+        $query = "SELECT ParentProcessId FROM Win32_Process WHERE ProcessId = $ProcessId"
+        $parentID = (Get-WmiObject -Query $query).ParentProcessId
+        $parentID
+    }
 }

--- a/windows/settings/powershell/libs/commonSettings.inc.ps1
+++ b/windows/settings/powershell/libs/commonSettings.inc.ps1
@@ -42,6 +42,9 @@ Set-StrictMode -version latest
 #>
 
 function Init_ScriptEnvironments() {
+	# Guard against re-initialization: skip setup if already initialized
+	if (Test-Path Variable:Global:agBaseDir) { return }
+
 	Set-Variable -Scope Global -Option ReadOnly -Name agBaseDir -Value (Split-Path -Path $PROFILE)
 	Set-Variable -Scope Global -Option ReadOnly -Name agLIBSDIR -Value $agBaseDir'/libs/' -Description 'common libs directory'
 	Set-Variable -Scope Global -Option ReadOnly -Name agSCRIPTSDIR -Value $agBaseDir'/scripts/' -Description 'Common scripts directory'

--- a/windows/settings/powershell/libs/keyconfig.inc.ps1
+++ b/windows/settings/powershell/libs/keyconfig.inc.ps1
@@ -1,30 +1,30 @@
 <#
-	.SYNOPSIS
-	key customize script
+    .SYNOPSIS
+    key customize script
 
-	.DESCRIPTION
-	key function customize : config key of powershell command line
+    .DESCRIPTION
+    key function customize : config key of powershell command line
   default customize: wz (Wz/diamond cursor key)
 
-	.NOTES
-	@Author		Furukawa, Atsushi <atsushifx@aglabo.com>
-	@License 	MIT License https://opensource.org/licenses/MIT
+    .NOTES
+    @Author     Furukawa, Atsushi <atsushifx@aglabo.com>
+    @License    MIT License https://opensource.org/licenses/MIT
 
-	@date		2023-05-31
-	@Version 	1.0.0
+    @date       2023-05-31
+    @Version    1.0.0
 
 THIS CODE IS MADE AVAILABLE AS IS, WITHOUT WARRANTY OF ANY KIND.
 THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS CODE REMAINS WITH THE USER.
 #>
 
 <#
-	.SYNOPSIS
+    .SYNOPSIS
     key customize like wz editor
 
-	.DESCRIPTION
-	key config/customize like WzEditor
-	diamond key -> move cursor & history
-	ctrl+p: select history with fzf and set command line to execute this.
+    .DESCRIPTION
+    key config/customize like WzEditor
+    diamond key -> move cursor & history
+    ctrl+p: select history with fzf and set command line to execute this.
 
 
   .EXAMPLE
@@ -33,51 +33,51 @@ THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS CODE REMAINS WITH
 
 #>
 function keyConfig_wzLike() {
-	Set-PSReadLineOption -EditMode windows
+    Set-PSReadLineOption -EditMode windows
 
+    # windows default Ctrl+Shift+<Key>
+    Set-PSReadLineKeyHandler -chord Ctrl+A -function SelectAll
+    Set-PSReadLineKeyHandler -chord Ctrl+X -function cut
+    Set-PSReadLineKeyHandler -chord Ctrl+C -function copy
 
-	# windows default Ctrl+Shift+<Key>
-	Set-PSReadLineKeyHandler -chord Ctrl+A -function SelectAll
-	Set-PSReadLineKeyHandler -chord Ctrl+X -function cut
-	Set-PSReadLineKeyHandler -chord Ctrl+C -function copy
+    # exit shell
+    $keyConfig_exit = @{
+        BriefDescription = 'exit'
+        LongDescription  = 'input exit {ENTER}'
+        ScriptBlock      = {
+            Execute-Command "exit" -send -enter
+        }
+    }
+    Set-PSReadLineKeyHandler -chord Ctrl+Z @keyConfig_exit
 
-	# exit shell
-	$keyConfig_exit = @{
-		BriefDescription = 'exit'
-		LongDescription  = 'input exit {ENTER}'
-		ScriptBlock      = {
-			Execute_Command "exit" -send -enter
-		}
-	}
-	Set-PSReadLineKeyHandler -chord Ctrl+Z @keyConfig_exit
+    # Wz/Vz like +alpha
+    Set-PSReadLineKeyHandler -chord Ctrl+a -function ShellBackwardWord
+    Set-PSReadLineKeyHandler -chord Ctrl+s -function BackwardChar
+    Set-PSReadLineKeyHandler -chord Ctrl+d -function ForwardChar
+    Set-PSReadLineKeyHandler -chord Ctrl+f -function ShellForwardWord
 
-	# Wz/Vz like +alpha
-	Set-PSReadLineKeyHandler -chord Ctrl+a -function ShellBackwardWord
-	Set-PSReadLineKeyHandler -chord Ctrl+s -function BackwardChar
-	Set-PSReadLineKeyHandler -chord Ctrl+d -function ForwardChar
-	Set-PSReadLineKeyHandler -chord Ctrl+f -function ShellForwardWord
+    Set-PSReadLineKeyHandler -chord Ctrl+g -function DeleteChar
+    Set-PSReadLineKeyHandler -chord Ctrl+t -function DeleteWord
+    Set-PSReadLineKeyHandler -chord Ctrl+u -function DeleteLine
+    Set-PSReadLineKeyHandler -chord Ctrl+y -function Paste
+    Set-PSReadLineKeyHandler -chord Ctrl+j -function Paste
+    Set-PSReadLineKeyHandler -chord Ctrl+l -function MenuComplete
 
-	Set-PSReadLineKeyHandler -chord Ctrl+g -function DeleteChar
-	Set-PSReadLineKeyHandler -chord Ctrl+t -function DeleteWord
-	Set-PSReadLineKeyHandler -chord Ctrl+u -function DeleteLine
-	Set-PSReadLineKeyHandler -chord Ctrl+y -function Paste
-	Set-PSReadLineKeyHandler -chord Ctrl+j -function Paste
+    # history
+    $keyConfig = @{
+        BriefDescription = 'select & execute history'
+        LongDescription  = 'select history with fzf & execute this'
+        ScriptBlock      = { Execute-History -send }
+    }
 
-	# history
-	$keyConfig = @{
-		BriefDescription = 'select & execute history'
-		LongDescription  = 'select history with fzf & execute this'
-		ScriptBlock      = { Execute_History -send }
-	}
+    Set-PSReadLineKeyHandler -chord Ctrl+p @keyConfig
+    Set-PSReadLineKeyHandler -chord Ctrl+n -function NextHistory
 
-	Set-PSReadLineKeyHandler -chord Ctrl+p @keyConfig
-	Set-PSReadLineKeyHandler -chord Ctrl+n -function NextHistory
+    Set-PSReadLineKeyHandler -chord Ctrl+e -function PreviousHistory
+    Set-PSReadLineKeyHandler -chord Ctrl+x -function NextHistory
 
-	Set-PSReadLineKeyHandler -chord Ctrl+e -function PreviousHistory
-	Set-PSReadLineKeyHandler -chord Ctrl+x -function NextHistory
-
-	# zsh like tab completion
-	# Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
+    # zsh like tab completion
+    # Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
 }
 
 keyConfig_wzLike

--- a/windows/settings/powershell/scripts/pwsh-wakatime.ps1
+++ b/windows/settings/powershell/scripts/pwsh-wakatime.ps1
@@ -1,4 +1,4 @@
-Import-Module posh-git
+# Import-Module posh-git
 
 ## PROMPT MANAGEMENT ###########################################################
 
@@ -11,15 +11,6 @@ Import-Module posh-git
         Causes a WakaTime heartbeat sent at the current session's prompt.
 #>
 
-# Use the same procedure as in conda to nest prompts.
-if (Test-Path Function:\prompt) {
-    Rename-Item Function:\prompt WakaTimePromptBackup
-} else {
-    function WakaTimePromptBackup() {
-        # Restore a basic prompt if the definition is missing.
-        "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
-    }
-}
 function Test-Wakatime {return $(if($(where.exe wakatime)) {$True} else {$False})}
 
 function Send-WakaTimeHeartbeat(){
@@ -74,4 +65,17 @@ function Send-HeartbeatAtPrompt() {
         WakaTimePromptBackup;
     }
 }
-Send-HeartbeatAtPrompt
+
+# Use the same procedure as in conda to nest prompts.
+# Guard against re-loading: skip setup if already initialized.
+if (-not (Test-Path Function:\WakaTimePromptBackup)) {
+    if (Test-Path Function:\prompt) {
+        Rename-Item Function:\prompt WakaTimePromptBackup
+    } else {
+        function WakaTimePromptBackup() {
+            # Restore a basic prompt if the definition is missing.
+            "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+        }
+    }
+    Send-HeartbeatAtPrompt
+}


### PR DESCRIPTION
## Overview

**Summary**:
Add PowerShell completions for git-wt and volta, protect pnpm via sfw wrapper.
enable carapace, and normalize indentation across libs.

**Background / Motivation**:
PowerShell 設定において、補完スクリプトの整備・pnpm の安全実行・コードスタイルの統一が必要だった。
`cliFunctions` と `keyconfig` ライブラリのインデントがタブ混在だったため、PowerShell 命名規則への準拠と合わせて正規化した。

---

## Changes

- `Microsoft.PowerShell_profile.ps1`: `Invoke-SfwPnpm` 関数追加、carapace 補完有効化、履歴重複排除オプション追加
- `completion.d/git-wt.ps1`: `git-wt` の PowerShell 補完スクリプトを新規追加
- `completion.d/volta.ps1`: volta 補完の初期化コードを有効化
- `libs/cliFunctions.inc.ps1`: インデント正規化（タブ → スペース 4つ）、関数名を PowerShell 命名規則 (`Verb-Noun`) に変更
- `libs/keyconfig.inc.ps1`: インデント正規化、関数名を PowerShell 命名規則に変更
- `.vscode/cSpell/dicts/powershell.dic`: `ramdisk` を辞書に追加

---

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

> N/A

---

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes

### Test Plan

以下を確認:

```powershell
# プロファイル再読み込みテスト
. $PROFILE

# pnpm ラッパー確認
pnpm --version

# 補完動作確認 (手動 Tab キー操作)
git-wt <Tab>
volta <Tab>
```
