### PR TITLE
fix(powershell): fix cursor position handling in git-wt-completion

### DIFF
--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -1,0 +1,60 @@
+// src: ./dprint.jsonc
+// @(#) : dprint configuration for project formatting
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+{
+  "$schema": "https://dprint.dev/schemas/v0.json",
+  // Global settings
+  "lineWidth": 120,
+  "indentWidth": 2,
+  "useTabs": false,
+  "newLineKind": "lf",
+  // Include/Exclude patterns
+  "includes": [
+    "**/*.js",
+    "**/*.ts",
+    "**/*.json",
+    "**/*.jsonc",
+    "**/*.yml",
+    "**/*.yaml",
+    // Documents
+    "**/*.md",
+  ],
+  "excludes": [
+    "**/node_modules/**",
+    "**/*lock",
+    "**/lib/**",
+    "**/module/**",
+    "**/dist/**",
+    //
+    "**lock.*",
+    // Documents
+    "CONTRIBUTING**.md",
+    "CODE_OF_CONDUCT**.md",
+  ],
+  // Plugins
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.95.15.wasm",
+    "https://plugins.dprint.dev/json-0.21.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.21.1.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
+  ],
+  // Language-specific settings
+  "typescript": {
+    "indentWidth": 2,
+    "useTabs": false,
+    "quoteStyle": "preferSingle",
+    "preferSingleLine": false,
+    "useBraces": "always",
+    "arrowFunction.useParentheses": "force",
+    "trailingCommas": "onlyMultiLine",
+  },
+  "json": {},
+  "markdown": {
+    "emphasisKind": "asterisks",
+  },
+  "yaml": {},
+}

--- a/windows/settings/powershell/completion.d/git-wt-completion.ps1
+++ b/windows/settings/powershell/completion.d/git-wt-completion.ps1
@@ -58,14 +58,14 @@ if (Get-Command git-wt -ErrorAction SilentlyContinue) {
         $gitWtAsSubcommandCompleter = {
             param($wordToComplete, $commandAst, $cursorPosition)
 
-            $cmdText = $commandAst.Extent.Text.Substring(
-                0, [math]::Min($cursorPosition, $commandAst.Extent.Text.Length)
-            )
+            # posh-git と同じ方式で textToComplete を構築（末尾スペース保持のためパディングが必要）
+            $padLength = $cursorPosition - $commandAst.Extent.StartOffset
+            $textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
 
             # git wt ... の場合のみ処理、それ以外は posh-git にフォールバック
-            if ($cmdText -notmatch '^git\s+wt(\s|$)') {
+            if ($textToComplete -notmatch '^git\s+wt(\s|$)') {
                 if (Get-Command Expand-GitCommand -ErrorAction SilentlyContinue) {
-                    return Expand-GitCommand $cmdText
+                    return Expand-GitCommand $textToComplete
                 }
                 return
             }


### PR DESCRIPTION
## Overview

**Summary**
Fix cursor position handling in git worktree completion script to retain trailing spaces

**Background / Motivation**
補完時のカーソル位置計算が不正確だったため、末尾スペースが保持されず、正しく補完されないという問題があった。
posh-git の実装に合わせることで一貫性のある動作を実現する。

---

## Changes

- `windows/settings/powershell/completion.d/git-wt-completion.ps1`
  - `$cmdText` 変数を廃止し、posh-git と同じ方式で `$textToComplete` を構築
  - `$cursorPosition - $commandAst.Extent.StartOffset` でパディング長を計算し、末尾スペースを保持
  - `Expand-GitCommand` へのフォールバック時も `$textToComplete` を使用するよう修正

---

## Change Type (optional)

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

> Closes #23

---

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes

- PowerShell で `git wt <Tab>` を実行し、補完候補が表示されることを確認
- コマンドの末尾にスペースを入力した状態での補完が正しく動作することを確認
- `Expand-GitCommand` フォールバック時の動作確認
