### PR TITLE
config(windows): update linter, shell, and tool configs

### DIFF
--- a/windows/.config/bd/config.yaml
+++ b/windows/.config/bd/config.yaml
@@ -5,19 +5,16 @@
 
 # Issue prefix for this repository (used by bd init)
 # If not set, bd init will auto-detect from directory name
-# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# Example: issue-prefix: "myProject" creates issues like "myProject-1", "myProject-2", etc.
 # issue-prefix: ""
 issue-prefix: "agl"
-
 # Use no-db mode: JSONL-only, no Dolt database
 # When true, bd will use .beads/issues.jsonl as the source of truth
 # no-db: false
 no-db: true
-
 # Disable daemon for RPC communication (forces direct database access)
 # no-daemon: false
 no-daemon: true
-
 # Disable auto-flush of database to JSONL after mutations
 # no-auto-flush: false
 
@@ -27,7 +24,6 @@ no-auto-import: true
 # Enable JSON output by default
 # json: false
 json: true
-
 # Feedback title formatting for mutating commands (create/update/close/dep/edit)
 # 0 = hide titles, N > 0 = truncate to N characters
 # output:
@@ -36,6 +32,9 @@ json: true
 # Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
 # actor: ""
 actor: "atsushifx"
+metrics:
+  disabled: true
+  endpoint: "https://gastownhall-eventsapi.com/mp/collect"
 
 # Export events (audit trail) to .beads/events.jsonl on each flush/sync
 # When enabled, new events are appended incrementally using a high-water mark.

--- a/windows/.config/git/ignore
+++ b/windows/.config/git/ignore
@@ -48,4 +48,5 @@ $~*
 temp/
 tmp/
 
-**/.claude\settings.local.json
+## Local settings
+**/settings.local.json

--- a/windows/.config/glow/glow.yml
+++ b/windows/.config/glow/glow.yml
@@ -1,0 +1,10 @@
+# style name or JSON path (default "auto")
+style: "auto"
+# mouse support (TUI-mode only)
+mouse: true
+# use pager to display markdown
+pager: false
+# word-wrap at width
+width: 80
+# show all files, including hidden and ignored.
+all: false

--- a/windows/.config/linters/markdownlint/.markdownlint-cli2.yaml
+++ b/windows/.config/linters/markdownlint/.markdownlint-cli2.yaml
@@ -6,19 +6,20 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
+
 ## Files
 # globs:
 
 ## Ignores
 # ignore gitignore
 gitignore: true
-
 # ignore files globs
 ignores:
+  - "**/__tests__/**" # ignore test fixtures (raw)chatlog data)
   - ".serena/**"
   - ".tools/**"
-# - "temp/**"
-# - "tmp/**"
+  - "temp/**"
+  - "tmp/**"
 
 ## ruleset
 config:

--- a/windows/.config/linters/markdownlint/.markdownlint.yaml
+++ b/windows/.config/linters/markdownlint/.markdownlint.yaml
@@ -6,6 +6,7 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
+
 ## markdown lint rule configs
 #
 default: true
@@ -22,9 +23,13 @@ no-duplicate-heading:
 line-length:
   line_length: 120
   code_block_line_length: 120
+  tables: false # tables cannot be wrapped; exclude them from the line length check
 
 # list item
 ol-prefix: true
+
+# html
+no-inline-html: false
 
 # styles
 emphasis-style:

--- a/windows/.config/linters/textlint/textlintrc.yaml
+++ b/windows/.config/linters/textlint/textlintrc.yaml
@@ -24,6 +24,7 @@ rules:
       "preferInBody": "ですます",
       "preferInList": "",
     }
+    no-exclamation-question-mark: false
     ja-no-mixed-period:
       allowPeriodMarks:
         - ":"
@@ -31,11 +32,25 @@ rules:
       strict: false
   "@textlint-ja/preset-ai-writing": true
   preset-ja-spacing:
+    ja-no-space-around-slash: false
+    ja-no-space-around-parentheses: false
     ja-space-between-half-and-full-width:
       space:
         - alphabets
         - numbers
-  ja-hiraku: true
+    ja-space-around-code:
+      before: true
+      after: true
+    ja-space-around-link:
+      before: true
+      after: true
+    ja-space-around-strong:
+      before: true
+      after: true
+    ja-space-around-emphasis:
+      before: true
+      after: true
+  "@textlint-ja/no-synonyms": true
   common-misspellings: true
   no-mixed-zenkaku-and-hankaku-alphabet: true
   "@proofdict/proofdict":

--- a/windows/.config/pnpm/rc
+++ b/windows/.config/pnpm/rc
@@ -17,3 +17,6 @@ global-bin-dir=${XDG_DATA_HOME}/pnpm
 # peer devevdancy
 auto-install-peers=true
 strict-peer-dependencies=false
+
+## package store directory
+store-dir=${XDG_DATA_HOME}/pnpm/store

--- a/windows/settings/powershell/Microsoft.PowerShell_profile.ps1
+++ b/windows/settings/powershell/Microsoft.PowerShell_profile.ps1
@@ -29,6 +29,7 @@ if (Test-Path "W:") { # ramdisk exist
 
   $env:TEMP="W:\temp"
   $env:TMP="W:\temp"
+  $env:TMPDIR="/w/temp"
 }
 
 
@@ -84,7 +85,8 @@ function private:write-sudo-messages() {
 ## use firewall for npm,pnpm safer
 function Invoke-SfwPnpm() { & sfw pnpm @args }
 Set-Alias pnpm Invoke-SfwPnpm -Description { "safe pnpm" }
-
+function Invoke-RawPnpm() { & "C:/app/develop/volta/home/bin/pnpm.cmd" @args }
+Set-Alias pnpm-lazy Invoke-RawPnpm -Description { "raw pnpm without firewall" }
 
 ## input History Plugin
 Set-PSReadLineOption -PredictionSource HistoryAndPlugin


### PR DESCRIPTION
## Overview

**Summary**
Windows 環境の dotfiles について、linter / shell / 各種ツールの設定をまとめて更新する。

**Background / Motivation**
Windows 環境で dotfiles を運用するなかで、実態に合わなくなっていた設定を整理する必要があった。
markdownlint / textlint は一時ディレクトリやテストフィクスチャを誤検出し、日本語文書に
そぐわないルールが有効なままだった。あわせて glow の設定が未整備で、pnpm の store が
XDG 配下に置かれておらず、PowerShell では RAM ディスク使用時の一時ディレクトリと
firewall を経由しない pnpm 実行手段が不足していた。
これらをまとめて解消し、Windows 環境の設定を一貫した状態にする。

## Changes

### Core Changes

- `markdownlint/.markdownlint-cli2.yaml`: `temp/**` / `tmp/**` の ignore を有効化し、
  `**/__tests__/**` (テストフィクスチャ) を追加
- `markdownlint/.markdownlint.yaml`: 行長チェックからテーブルを除外 (`tables: false`)、
  `no-inline-html` を無効化
- `textlint/textlintrc.yaml`: `no-exclamation-question-mark` /
  `ja-no-space-around-slash` / `ja-no-space-around-parentheses` を無効化、
  `ja-space-around-{code,link,strong,emphasis}` を有効化、
  `@textlint-ja/no-synonyms` を追加
- `glow/glow.yml`: 新規追加 (style auto / width 80 / pager 無効)
- `pnpm/rc`: `store-dir=${XDG_DATA_HOME}/pnpm/store` を追加
- `bd/config.yaml`: コメント間の空行整理、および `metrics` セクションの追加
- `powershell/Microsoft.PowerShell_profile.ps1`: RAM ディスク検出時に
  `TMPDIR=/w/temp` を設定、firewall を経由しない `pnpm-lazy` エイリアスを追加
- `git/ignore`: `**/.claude\settings.local.json` を `**/settings.local.json` に修正
  (バックスラッシュ混じりで機能していなかったパターンの修正)

### Test Updates

N/A (設定ファイルのみの変更のため、テストの追加・更新はなし)

### Removed

- `textlint/textlintrc.yaml`: `ja-hiraku` ルールを削除

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #20

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists) — 設定ファイルのみのためテスト対象外
- [ ] Documentation updated (for user-facing changes) — ユーザー向け変更なし
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in
      implementation files — N/A (実装コードの変更なし)

## Breaking Change

なし。既存の設定を壊す変更は含まない。

## Additional Notes

**検証手順**

- markdownlint: `pnpm run lint:markdown`
- textlint: `pnpm run lint:text`
- PowerShell profile: 新規シェル起動で `$env:TMPDIR` と `pnpm-lazy` を確認
- glow / pnpm: `glow README.md`、`pnpm store path` で反映を確認

**レビュー時の注意**

- 設定ファイルのみの変更のため、BDD RGR サイクルの対象外
- `bd/config.yaml` の `metrics` セクションは bd ツールによる自動追記。
  テレメトリが `disabled: false` (送信有効) の状態でコミットされているため、
  意図しない場合はマージ前に無効化すること
